### PR TITLE
Bumps version of labelled progress bar to 1.0.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     // TMG
     implementation 'com.github.thementalgoose:android-components:3.0.0'
     implementation 'com.github.thementalgoose:android-utilities:2.0.1'
-    implementation 'com.github.thementalgoose:android-labelled-progress-bar:1.0.4'
+    implementation 'com.github.thementalgoose:android-labelled-progress-bar:1.0.5'
 
     // ColorSheet
     implementation 'petrov.kristiyan:colorpicker-library:1.1.10'


### PR DESCRIPTION
- Fixes bug where last value may not be shown in progress bar properly depending on update cycle